### PR TITLE
Corrige o problema de adaptação do tamanho das fontes

### DIFF
--- a/crint-site/src/components/FontSizeSystem.tsx
+++ b/crint-site/src/components/FontSizeSystem.tsx
@@ -2,14 +2,17 @@ import { faPlus, faMinus } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { MAX_FONT_MULTIPLIER, MIN_FONT_MULTIPLIER } from "../utils/constants";
 import { clampFontSize, getBaseFontSize, updateUserSettings, useSettings } from "../utils/utils";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import './FontSizeSystem.scss';
 
 const FontSizeSystem = () => {
     const context = useSettings();
     const { userSettings } = context;
+    const [screenWidth, setScreenWidth] = useState(window.innerWidth);
+    const [BASE_FONTSIZE, setBASE_FONTSIZE] = useState(getBaseFontSize());
 
-    const BASE_FONTSIZE = getBaseFontSize();
+    const MIN_FONT_SIZE = MIN_FONT_MULTIPLIER * BASE_FONTSIZE;
+    const MAX_FONT_SIZE = MAX_FONT_MULTIPLIER * BASE_FONTSIZE;
 
     // Atualiza a fonte global do site
     useEffect(() => {
@@ -21,36 +24,39 @@ const FontSizeSystem = () => {
     }, [userSettings.fontSize]);
 
     // Atualiza a fonte caso haja uma mudança repentina
-
-    /*
-    * Causa um erro que ao carregar o site pela primeira vez, ele sobrescreve o valor do usuário 
-    * 
-    * Talvez seja necessário remover a atualização dinâmica. Porém, é possível que uma atualização
-    * no modelo atual seja o bastante para resolver o problema.
-    * 
-    * Essa atualização partiria da função que atualiza o tamanho base da fonte.
-    * 
-    */
     useEffect(() => {
-        updateUserSettings(context, { fontSize: BASE_FONTSIZE });
-    }, [BASE_FONTSIZE]);
+        const updateScreenWidth = () => {
+            setScreenWidth(window.innerWidth);
+        }
 
+        window.addEventListener('resize', updateScreenWidth);
+
+        // Caso haja uma mudança no tamanho da tela, atualiza a fonte se necessário
+        if (BASE_FONTSIZE !== getBaseFontSize()) {
+            setBASE_FONTSIZE(getBaseFontSize());
+            setFontSize(0);
+        }
+
+        return (() => {
+            window.removeEventListener('resize', updateScreenWidth);
+        })
+    }, [screenWidth]);
+
+    // Atualiza a fonte do usuário
     const setFontSize = (offset: number) => {
         const newFontSize = clampFontSize(userSettings.fontSize + offset);
         updateUserSettings(context, { fontSize: newFontSize });
     }
 
-    console.log('Font size: ', userSettings.fontSize);
-
     return (
         <div className='options-root'>
             <div className='options-body'>
                 {
-                    userSettings.fontSize > (MIN_FONT_MULTIPLIER * BASE_FONTSIZE) &&
+                    userSettings.fontSize > MIN_FONT_SIZE &&
                     <button className='decrease button' onClick={() => setFontSize(-2)}><FontAwesomeIcon icon={faMinus} /></button>
                 }
                 {
-                    userSettings.fontSize < (MAX_FONT_MULTIPLIER * BASE_FONTSIZE) &&
+                    userSettings.fontSize < MAX_FONT_SIZE &&
                     <button className='increase button' onClick={() => setFontSize(2)}><FontAwesomeIcon icon={faPlus} /></button>
                 }
             </div>

--- a/crint-site/src/components/FontSizeSystem.tsx
+++ b/crint-site/src/components/FontSizeSystem.tsx
@@ -9,7 +9,7 @@ const FontSizeSystem = () => {
     const context = useSettings();
     const { userSettings } = context;
 
-    const BASE_FONTSIZE = getBaseFontSize()
+    const BASE_FONTSIZE = getBaseFontSize();
 
     // Atualiza a fonte global do site
     useEffect(() => {
@@ -21,14 +21,26 @@ const FontSizeSystem = () => {
     }, [userSettings.fontSize]);
 
     // Atualiza a fonte caso haja uma mudança repentina
+
+    /*
+    * Causa um erro que ao carregar o site pela primeira vez, ele sobrescreve o valor do usuário 
+    * 
+    * Talvez seja necessário remover a atualização dinâmica. Porém, é possível que uma atualização
+    * no modelo atual seja o bastante para resolver o problema.
+    * 
+    * Essa atualização partiria da função que atualiza o tamanho base da fonte.
+    * 
+    */
     useEffect(() => {
-        setFontSize(userSettings.fontSize);
+        updateUserSettings(context, { fontSize: BASE_FONTSIZE });
     }, [BASE_FONTSIZE]);
 
     const setFontSize = (offset: number) => {
         const newFontSize = clampFontSize(userSettings.fontSize + offset);
         updateUserSettings(context, { fontSize: newFontSize });
     }
+
+    console.log('Font size: ', userSettings.fontSize);
 
     return (
         <div className='options-root'>


### PR DESCRIPTION
Quando a página era recarregada, a fonte era atualizada para o tamanho base todas as vezes. Além disso, a atualização do tamanho base da fonte foi melhorada.